### PR TITLE
encode product name, and allow double escaping to avoid IIS issue

### DIFF
--- a/Elwin.GoGroceries/Client/Components/Forms/ProductForm.razor
+++ b/Elwin.GoGroceries/Client/Components/Forms/ProductForm.razor
@@ -3,6 +3,7 @@
 @using Elwin.GoGroceries.Client.Helpers;
 @using Elwin.GoGroceries.Contracts;
 @using Elwin.GoGroceries.Contracts.Post;
+@using System.Net;
 
 <MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors">
     <MudTextField T="string" Label="Name" Required="true" RequiredError="Shopping item requires a name!" @bind-Value="PostProduct.Name" Validation="@(new Func<string, Task<string>>(CheckNameDuplicate))" />
@@ -78,7 +79,7 @@
     {
         if (!string.IsNullOrEmpty(name) && Product?.Name != name)
         {
-            var res = await Http.GetAsync($"GroceryLists/checkProductExists/{ListId}/{name}");
+            var res = await Http.GetAsync($"GroceryLists/checkProductExists/{ListId}/" + Uri.EscapeDataString(name));
             var exists = await HttpResultHelper.Process(res, () => res.Content.ReadFromJsonAsync<bool>());
 
             if (exists) return "Product name already exists.";

--- a/Elwin.GoGroceries/Server/web.config
+++ b/Elwin.GoGroceries/Server/web.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <security>
+      <requestFiltering allowDoubleEscaping="true" />
+    </security>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
It was + causing issues, not ( )
See https://stackoverflow.com/questions/66654411/how-to-enable-double-escaping-in-net-core-webapi